### PR TITLE
refactor(ButtonRenderer): Follow ternary operator syntax

### DIFF
--- a/Medac-stars/src/main/java/medac/stars/ui/arena/ButtonRenderer.java
+++ b/Medac-stars/src/main/java/medac/stars/ui/arena/ButtonRenderer.java
@@ -1,39 +1,32 @@
 package medac.stars.ui.arena;
 
 
-import java.awt.Component;
-import javax.swing.JButton;
-import javax.swing.JTable;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.table.TableCellRenderer;
+import java.awt.*;
 
 
 class ButtonRenderer extends JButton implements TableCellRenderer {
-
     public ButtonRenderer() {
-      setOpaque(true);
+        setOpaque(true);
     }
-  
+
     /**
      * Funcion que devuelve un componente cuya funcion es obtener el render de una celda de la tabla.
-     * @param table Tabla que recibe la funcion
-     * @param value El valor del objeto
+     *
+     * @param table      Tabla que recibe la funcion
+     * @param value      El valor del objeto
      * @param isSelected si esta seleccionado o no
-     * @param hasFocus si esta clicado o no
-     * @param row linea de la tabla
-     * @param column columna de la tabla
+     * @param hasFocus   si esta clicado o no
+     * @param row        linea de la tabla
+     * @param column     columna de la tabla
      * @return el componente
      */
     public Component getTableCellRendererComponent(JTable table, Object value,
-        boolean isSelected, boolean hasFocus, int row, int column) {
-      if (isSelected) {
-        setForeground(table.getSelectionForeground());
-        setBackground(table.getSelectionBackground());
-      } else {
-        setForeground(table.getForeground());
-        setBackground(UIManager.getColor("Button.background"));
-      }
-      setText((value == null) ? "" : value.toString());
-      return this;
+                                                   boolean isSelected, boolean hasFocus, int row, int column) {
+        setForeground(isSelected ? table.getSelectionForeground() : table.getForeground());
+        setBackground(isSelected ? table.getSelectionBackground() : UIManager.getColor("Button.background"));
+        setText((value == null) ? "" : value.toString());
+        return this;
     }
-  }
+}


### PR DESCRIPTION
As we're using ternary operators on some of the getTableCellRendererComponent code, we follow the style on setForeground/setBackground